### PR TITLE
Making non-member content visible for admins

### DIFF
--- a/shortcodes.php
+++ b/shortcodes.php
@@ -24,7 +24,7 @@ class Shortcodes {
           return do_shortcode($content);
         break;
       case 'non-members':
-        if (!is_user_logged_in())
+        f (!is_user_logged_in() || current_user_can('administrator'))
           return do_shortcode($content);
         break;
     }

--- a/shortcodes.php
+++ b/shortcodes.php
@@ -24,7 +24,7 @@ class Shortcodes {
           return do_shortcode($content);
         break;
       case 'non-members':
-        f (!is_user_logged_in() || current_user_can('administrator'))
+        if (!is_user_logged_in() || current_user_can('administrator'))
           return do_shortcode($content);
         break;
     }


### PR DESCRIPTION
Hey,
I had a problem with non-member content regarding admin users.

So from now on admins will be able to see non’member content. It would be also great to get list of all user roles that exist so it would make VC even more flexible.

For example: I can make content visible to each role (now I need to modify your plugin by adding each role, though.)
